### PR TITLE
Add Media Embed to the BBCode FAQ

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1,5 +1,8 @@
 services:
     phpbb.mediaembed.listener:
         class: phpbb\mediaembed\event\main_listener
+        arguments:
+            - '@language'
+            - '@template'
         tags:
             - { name: event.listener }

--- a/language/en/help.php
+++ b/language/en/help.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ *
+ * phpBB Media Embed PlugIn extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2016 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+/**
+ * DO NOT CHANGE
+ */
+if (!defined('IN_PHPBB'))
+{
+	exit;
+}
+
+if (empty($lang) || !is_array($lang))
+{
+	$lang = array();
+}
+
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ » “ ” …
+//
+
+$lang = array_merge($lang, array(
+	'HELP_EMBEDDING_MEDIA'			=> 'Embedding Media',
+	'HELP_EMBEDDING_MEDIA_QUESTION'	=> 'How to embed media from other sites into posts',
+	'HELP_EMBEDDING_MEDIA_ANSWER'	=> 'Users can embed content such as videos and audio from allowed sites using 
+										the <strong>[media][/media]</strong> tags, or from simply posting a supported 
+										URL in plain text. For example:<br /><br />
+										<strong>[media]</strong>%1$s<strong>[/media]</strong>
+										<br /><br />As noted above, the link could also be used without the 
+										<strong>[media]</strong> tags.
+										<br /><br />The example shown here would generate:<br /><br />%2$s',
+	'HELP_EMBEDDING_MEDIA_DEMO'		=>	'https://youtu.be/QH2-TGUlwu4',
+));

--- a/tests/functional/media_embed_test.php
+++ b/tests/functional/media_embed_test.php
@@ -30,4 +30,15 @@ class media_embed_test extends \phpbb_functional_test_case
 		$crawler = self::request('GET', "viewtopic.php?t={$post['topic_id']}&sid={$this->sid}");
 		static::assertContains("//www.youtube.com/embed/{$youtubeId}", $crawler->filter("#post_content{$post['topic_id']} iframe")->attr('src'));
 	}
+
+	public function test_media_embed_help()
+	{
+		$this->add_lang_ext('phpbb/mediaembed', 'help');
+
+		$crawler = self::request('GET', 'app.php/help/bbcode');
+		$this->assertContainsLang('HELP_EMBEDDING_MEDIA', $crawler->filter('#faqlinks')->text());
+
+		preg_match('/https:\/\/youtu\.be\/(.*)/', $this->lang('HELP_EMBEDDING_MEDIA_DEMO'), $matches);
+		static::assertContains("//www.youtube.com/embed/{$matches[1]}", $crawler->filter('body iframe')->attr('src'));
+	}
 }


### PR DESCRIPTION
This adds the new media bbcode usage to the bbcode FAQ so user's can know how to use it. There's even a working example 👍 

![screen shot 2016-09-13 at 1 28 55 pm](https://cloud.githubusercontent.com/assets/303711/18490290/269b2808-79b6-11e6-9077-b7c4157cc631.png)