### PR TITLE
Add signature control

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -100,7 +100,10 @@ class main_module
 			break;
 
 			case 'settings':
-				$this->display($mode, ['S_MEDIA_EMBED_BBCODE' => $this->config['media_embed_bbcode']]);
+				$this->display($mode, [
+					'S_MEDIA_EMBED_BBCODE'		=> $this->config['media_embed_bbcode'],
+					'S_MEDIA_EMBED_ALLOW_SIG'	=> $this->config['media_embed_allow_sig'],
+				]);
 			break;
 		}
 	}
@@ -189,6 +192,7 @@ class main_module
 		$this->check_form_key();
 
 		$this->config->set('media_embed_bbcode', $this->request->variable('media_embed_bbcode', 0));
+		$this->config->set('media_embed_allow_sig', $this->request->variable('media_embed_allow_sig', 0));
 
 		$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_PHPBB_MEDIA_EMBED_SETTINGS');
 

--- a/adm/style/acp_phpbb_mediaembed_settings.html
+++ b/adm/style/acp_phpbb_mediaembed_settings.html
@@ -11,6 +11,11 @@
 			<dd><label><input type="radio" class="radio" name="media_embed_bbcode" id="media_embed_bbcode" value="1" {% if S_MEDIA_EMBED_BBCODE %}checked="checked"{% endif %}/> {{ lang('YES') }}</label>
 				<label><input type="radio" class="radio" name="media_embed_bbcode" value="0" {% if not S_MEDIA_EMBED_BBCODE %}checked="checked"{% endif %} /> {{ lang('NO') }}</label></dd>
 		</dl>
+		<dl>
+			<dt><label for="media_embed_allow_sig">{{ lang('ACP_MEDIA_ALLOW_SIG') ~ lang('COLON') }}</label><br /><span>{{ lang('ACP_MEDIA_ALLOW_SIG_EXPLAIN') }}</span></dt>
+			<dd><label><input type="radio" class="radio" name="media_embed_allow_sig" id="media_embed_allow_sig" value="1" {% if S_MEDIA_EMBED_ALLOW_SIG %}checked="checked"{% endif %}/> {{ lang('YES') }}</label>
+				<label><input type="radio" class="radio" name="media_embed_allow_sig" value="0" {% if not S_MEDIA_EMBED_ALLOW_SIG %}checked="checked"{% endif %} /> {{ lang('NO') }}</label></dd>
+		</dl>
 	</fieldset>
 	<fieldset class="submit-buttons">
 		<input class="button1" type="submit" id="submit" name="submit" value="{{ lang('SUBMIT') }}" />&nbsp;

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"extra": {
 		"display-name": "phpBB Media Embed PlugIn",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.2.0-rc2"
+			"phpbb/phpbb": ">=3.2.0-RC2"
 		},
 		"version-check": {
 			"host": "version.phpbb.com",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"extra": {
 		"display-name": "phpBB Media Embed PlugIn",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.2.0"
+			"phpbb/phpbb": ">=3.2.0-rc2"
 		},
 		"version-check": {
 			"host": "version.phpbb.com",

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -29,12 +29,17 @@ class main_listener implements EventSubscriberInterface
 	/** @var \phpbb\template\template $template */
 	protected $template;
 
+	/** @var bool $signature Posting mode is signature */
+	protected $signature = false;
+
 	public static function getSubscribedEvents()
 	{
 		return [
 			'core.text_formatter_s9e_configure_after'	=> 'configure_media_embed',
 			'core.display_custom_bbcodes'				=> 'setup_media_bbcode',
 			'core.help_manager_add_block_before'		=> 'media_embed_help',
+			'core.message_parser_check_message'			=> 'set_signature',
+			'core.text_formatter_s9e_parser_setup'		=> 'disable_in_signature',
 		];
 	}
 
@@ -111,6 +116,36 @@ class main_listener implements EventSubscriberInterface
 				'FAQ_ANSWER'	=> $this->language->lang('HELP_EMBEDDING_MEDIA_ANSWER', $demo_text, $demo_display, $list_sites),
 			]);
 		}
+	}
+
+	/**
+	 * Set the signature property.
+	 * True if posting mode is signature, false otherwise.
+	 *
+	 * @param \phpbb\event\data $event The event object
+	 */
+	public function set_signature($event)
+	{
+		$this->signature = $event['mode'] === 'sig';
+	}
+
+	/**
+	 * Disable the Media Embed plugin when posting mode is a signature
+	 *
+	 * @param \phpbb\event\data $event The event object
+	 */
+	public function disable_in_signature($event)
+	{
+		if (!$this->signature || $this->config->offsetGet('media_embed_allow_sig'))
+		{
+			return;
+		}
+
+		/** @var \phpbb\textformatter\s9e\parser $service  */
+		$service = $event['parser'];
+		$parser = $service->get_parser();
+		$parser->disablePlugin('MediaEmbed');
+		$parser->disableTag('MEDIA');
 	}
 
 	/**

--- a/ext.php
+++ b/ext.php
@@ -17,18 +17,20 @@ class ext extends \phpbb\extension\base
 	 */
 	public function is_enableable()
 	{
-		return $this->s9e_textformatter_installed() && !$this->s9e_mediamebed_installed();
+		return $this->phpbb_version_is_valid() && !$this->s9e_mediamebed_installed();
 	}
 
 	/**
-	 * Check if s9e TextFormatter is installed (it must be
-	 * to enable this extension).
+	 * Check the installed phpBB version meets this
+	 * extension's requirements.
+	 *
+	 * Requires phpBB 3.2.0-rc2 and TextFormatter 0.8.1
 	 *
 	 * @return bool
 	 */
-	public function s9e_textformatter_installed()
+	public function phpbb_version_is_valid()
 	{
-		return class_exists('\s9e\TextFormatter\Configurator');
+		return phpbb_version_compare(PHPBB_VERSION, '3.2.0-rc2', '>=');
 	}
 
 	/**

--- a/language/en/acp.php
+++ b/language/en/acp.php
@@ -24,6 +24,8 @@ $lang = array_merge($lang, array(
 	'ACP_MEDIA_SETTINGS_EXPLAIN'		=> 'Here you can configure the settings for the Media Embed PlugIn.',
 	'ACP_MEDIA_DISPLAY_BBCODE'			=> 'Display <samp>[MEDIA]</samp> BBCode on posting page',
 	'ACP_MEDIA_DISPLAY_BBCODE_EXPLAIN'	=> 'If disallowed, the BBCode button will not be displayed, however users can still use the <samp>[media]</samp> tag in their posts',
+	'ACP_MEDIA_ALLOW_SIG'				=> 'Allow in user signatures',
+	'ACP_MEDIA_ALLOW_SIG_EXPLAIN'		=> 'Allow links in user signatures to be displayed as embedded media content.',
 
 	// Manage sites
 	'ACP_MEDIA_MANAGE'					=> 'Manage Media Embed Sites',

--- a/migrations/m2_signature_config.php
+++ b/migrations/m2_signature_config.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ *
+ * phpBB Media Embed PlugIn extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2016 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\mediaembed\migrations;
+
+/**
+ * Migration 2: Add a config var for the signature setting
+ */
+class m2_signature_config extends \phpbb\db\migration\migration
+{
+	public function effectively_installed()
+	{
+		return $this->config->offsetExists('media_embed_allow_sig');
+	}
+
+	public static function depends_on()
+	{
+		return ['\phpbb\mediaembed\migrations\m1_install_data'];
+	}
+
+	public function update_data()
+	{
+		return [
+			['config.add', ['media_embed_allow_sig', 0]],
+		];
+	}
+}


### PR DESCRIPTION
Adds an ACP option to allow (or not) links in user signatures to be converted to embedded media.

Depends on fixing phpBB's reparser cron https://github.com/phpbb/phpbb/pull/4479

Also will depend on the release of phpBB 3.2.0-rc2 for the minimum version

Closes #11 