### PR TITLE
Handle disabled sites in the ACP better

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -136,15 +136,13 @@ class main_module
 		$configurator = $this->container->get('text_formatter.s9e.factory')->get_configurator();
 		foreach ($configurator->MediaEmbed->defaultSites as $siteId => $siteConfig)
 		{
-			if (isset($configurator->BBCodes[$siteId]))
-			{
-				continue;
-			}
-
+			$disabled = isset($configurator->BBCodes[$siteId]);
 			$sites[] = [
 				'id'		=> $siteId,
 				'name'		=> $siteConfig['name'],
+				'title'		=> $this->language->lang($disabled ? 'ACP_MEDIA_SITE_DISABLED' : 'ACP_MEDIA_SITE_TITLE', $siteId),
 				'enabled'	=> in_array($siteId, $this->get_enabled_sites()),
+				'disabled'	=> $disabled,
 			];
 		}
 

--- a/adm/style/acp_phpbb_mediaembed_manage.html
+++ b/adm/style/acp_phpbb_mediaembed_manage.html
@@ -11,8 +11,8 @@
 				{% for site in sites %}
 					<td style="width:25%">
 						{% if site %}
-							<label style="font-size:1em;">
-								<input type="checkbox" class="radio" name="mark[]" value="{{ site.id }}"{% if site.enabled %} checked{% endif %} /> {{ site.name }}
+							<label style="font-size:1em;" title="{{ site.title }}">
+								<input type="checkbox" class="radio" name="mark[]" value="{{ site.id }}"{% if site.enabled %} checked{% elseif site.disabled %} disabled{% endif %} /> {{ site.name }}
 							</label>
 						{% endif %}
 					</td>

--- a/adm/style/acp_phpbb_mediaembed_manage.html
+++ b/adm/style/acp_phpbb_mediaembed_manage.html
@@ -12,7 +12,7 @@
 					<td style="width:25%">
 						{% if site %}
 							<label style="font-size:1em;" title="{{ site.title }}">
-								<input type="checkbox" class="radio" name="mark[]" value="{{ site.id }}"{% if site.enabled %} checked{% elseif site.disabled %} disabled{% endif %} /> {{ site.name }}
+								<input type="checkbox" class="radio" name="mark[]" value="{{ site.id }}"{% if site.disabled %} disabled{% elseif site.enabled %} checked{% endif %} /> {{ site.name }}
 							</label>
 						{% endif %}
 					</td>

--- a/language/en/acp.php
+++ b/language/en/acp.php
@@ -27,7 +27,7 @@ $lang = array_merge($lang, array(
 	'ACP_MEDIA_ALLOW_SIG'				=> 'Allow in user signatures',
 	'ACP_MEDIA_ALLOW_SIG_EXPLAIN'		=> 'Allow user signatures to display embedded media content.',
 	'ACP_MEDIA_SITE_TITLE'				=> 'Site id: %s',
-	'ACP_MEDIA_SITE_DISABLED'			=> 'This site conflicts with an existing BBCode: [%s].',
+	'ACP_MEDIA_SITE_DISABLED'			=> 'This site conflicts with an existing BBCode: [%s]',
 
 	// Manage sites
 	'ACP_MEDIA_MANAGE'					=> 'Manage Media Embed Sites',

--- a/language/en/acp.php
+++ b/language/en/acp.php
@@ -26,6 +26,8 @@ $lang = array_merge($lang, array(
 	'ACP_MEDIA_DISPLAY_BBCODE_EXPLAIN'	=> 'If disallowed, the BBCode button will not be displayed, however users can still use the <samp>[media]</samp> tag in their posts',
 	'ACP_MEDIA_ALLOW_SIG'				=> 'Allow in user signatures',
 	'ACP_MEDIA_ALLOW_SIG_EXPLAIN'		=> 'Allow user signatures to display embedded media content.',
+	'ACP_MEDIA_SITE_TITLE'				=> 'Site id: %s',
+	'ACP_MEDIA_SITE_DISABLED'			=> 'This site conflicts with an existing BBCode: [%s].',
 
 	// Manage sites
 	'ACP_MEDIA_MANAGE'					=> 'Manage Media Embed Sites',


### PR DESCRIPTION
Instead of hiding sites that can't be used because o bbcode already exists, display it in the ACP, but make disabled and at some info as a tooltip.