### PR TITLE
Add option for parsing plain URLs

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -111,6 +111,7 @@ class main_module
 		$this->template->assign_vars([
 			'S_MEDIA_EMBED_BBCODE'		=> $this->config['media_embed_bbcode'],
 			'S_MEDIA_EMBED_ALLOW_SIG'	=> $this->config['media_embed_allow_sig'],
+			'S_MEDIA_EMBED_PARSE_URLS'	=> $this->config['media_embed_parse_urls'],
 			'U_ACTION'					=> $this->u_action,
 		]);
 	}
@@ -174,8 +175,7 @@ class main_module
 	{
 		$this->config_text->set('media_embed_sites', json_encode($this->request->variable('mark', [''])));
 
-		$this->cache->destroy($this->container->getParameter('text_formatter.cache.parser.key'));
-		$this->cache->destroy($this->container->getParameter('text_formatter.cache.renderer.key'));
+		$this->purge_textformatter_cache();
 
 		$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_PHPBB_MEDIA_EMBED_MANAGE');
 
@@ -189,9 +189,21 @@ class main_module
 	{
 		$this->config->set('media_embed_bbcode', $this->request->variable('media_embed_bbcode', 0));
 		$this->config->set('media_embed_allow_sig', $this->request->variable('media_embed_allow_sig', 0));
+		$this->config->set('media_embed_parse_urls', $this->request->variable('media_embed_parse_urls', 0));
+
+		$this->purge_textformatter_cache();
 
 		$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_PHPBB_MEDIA_EMBED_SETTINGS');
 
 		trigger_error($this->language->lang('CONFIG_UPDATED') . adm_back_link($this->u_action));
+	}
+
+	/**
+	 * Purge cached TextFormatter files
+	 */
+	protected function purge_textformatter_cache()
+	{
+		$this->cache->destroy($this->container->getParameter('text_formatter.cache.parser.key'));
+		$this->cache->destroy($this->container->getParameter('text_formatter.cache.renderer.key'));
 	}
 }

--- a/adm/style/acp_phpbb_mediaembed_settings.html
+++ b/adm/style/acp_phpbb_mediaembed_settings.html
@@ -16,6 +16,11 @@
 			<dd><label><input type="radio" class="radio" name="media_embed_allow_sig" id="media_embed_allow_sig" value="1" {% if S_MEDIA_EMBED_ALLOW_SIG %}checked="checked"{% endif %}/> {{ lang('YES') }}</label>
 				<label><input type="radio" class="radio" name="media_embed_allow_sig" value="0" {% if not S_MEDIA_EMBED_ALLOW_SIG %}checked="checked"{% endif %} /> {{ lang('NO') }}</label></dd>
 		</dl>
+		<dl>
+			<dt><label for="media_embed_parse_urls">{{ lang('ACP_MEDIA_PARSE_URLS') ~ lang('COLON') }}</label><br /><span>{{ lang('ACP_MEDIA_PARSE_URLS_EXPLAIN') }}</span></dt>
+			<dd><label><input type="radio" class="radio" name="media_embed_parse_urls" id="media_embed_parse_urls" value="1" {% if S_MEDIA_EMBED_PARSE_URLS %}checked="checked"{% endif %}/> {{ lang('YES') }}</label>
+				<label><input type="radio" class="radio" name="media_embed_parse_urls" value="0" {% if not S_MEDIA_EMBED_PARSE_URLS %}checked="checked"{% endif %} /> {{ lang('NO') }}</label></dd>
+		</dl>
 	</fieldset>
 	<fieldset class="submit-buttons">
 		<input class="button1" type="submit" id="submit" name="submit" value="{{ lang('SUBMIT') }}" />&nbsp;

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -78,6 +78,12 @@ class main_listener implements EventSubscriberInterface
 
 			$configurator->MediaEmbed->add($siteId);
 		}
+
+		// Disable plain url parsing
+		if ($this->config->offsetGet('media_embed_parse_urls') == 0)
+		{
+			unset($configurator->MediaEmbed);
+		}
 	}
 
 	/**

--- a/language/en/acp.php
+++ b/language/en/acp.php
@@ -23,9 +23,11 @@ $lang = array_merge($lang, array(
 	'ACP_MEDIA_SETTINGS'				=> 'Media Embed Settings',
 	'ACP_MEDIA_SETTINGS_EXPLAIN'		=> 'Here you can configure the settings for the Media Embed PlugIn.',
 	'ACP_MEDIA_DISPLAY_BBCODE'			=> 'Display <samp>[MEDIA]</samp> BBCode on posting page',
-	'ACP_MEDIA_DISPLAY_BBCODE_EXPLAIN'	=> 'If disallowed, the BBCode button will not be displayed, however users can still use the <samp>[media]</samp> tag in their posts',
+	'ACP_MEDIA_DISPLAY_BBCODE_EXPLAIN'	=> 'If disallowed, the BBCode button will not be displayed, however users can still use the <samp>[media]</samp> tag in their posts.',
 	'ACP_MEDIA_ALLOW_SIG'				=> 'Allow in user signatures',
 	'ACP_MEDIA_ALLOW_SIG_EXPLAIN'		=> 'Allow user signatures to display embedded media content.',
+	'ACP_MEDIA_PARSE_URLS'				=> 'Convert plain URLs',
+	'ACP_MEDIA_PARSE_URLS_EXPLAIN'		=> 'Enable this to convert plain URLs (not wrapped in <samp>[media]</samp> or <samp>[url]</samp> tags) to embedded media content. Note that changing this setting will only affect new posts, as exisiting posts have already been parsed.',
 	'ACP_MEDIA_SITE_TITLE'				=> 'Site id: %s',
 	'ACP_MEDIA_SITE_DISABLED'			=> 'This site conflicts with an existing BBCode: [%s]',
 

--- a/migrations/m3_plain_urls_config.php
+++ b/migrations/m3_plain_urls_config.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ *
+ * phpBB Media Embed PlugIn extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2018 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\mediaembed\migrations;
+
+/**
+ * Migration 3: Add a config var for parsing plain urls
+ */
+class m3_plain_urls_config extends \phpbb\db\migration\migration
+{
+	public function effectively_installed()
+	{
+		return $this->config->offsetExists('media_embed_parse_urls');
+	}
+
+	public static function depends_on()
+	{
+		return ['\phpbb\mediaembed\migrations\m1_install_data'];
+	}
+
+	public function update_data()
+	{
+		return [
+			['config.add', ['media_embed_parse_urls', 1]],
+		];
+	}
+}


### PR DESCRIPTION
Option to turn off the automatic conversion of plain URLs into embedded media when applicable

Also, if user in posting disables automatically parse urls, then we will now respect that and not auto convert to embedded media too.

Requested option: https://www.phpbb.com/customise/db/extension/mediaembed/support/topic/192081