### PR TITLE
Fix issues coming with phpBB 3.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "An official phpBB extension that allows users to embed content from allowed sites using a [media] BBCode, or from simply posting a supported URL in plain text.",
 	"homepage": "https://www.phpbb.com",
-	"version": "1.0.3",
+	"version": "1.0.4-dev",
 	"license": "GPL-2.0-only",
 	"authors": [
 		{

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -100,6 +100,7 @@ class main_listener implements EventSubscriberInterface
 		// Disable plain url parsing
 		if (!$this->config->offsetGet('media_embed_parse_urls'))
 		{
+			$configurator->MediaEmbed->finalize();
 			unset($configurator->MediaEmbed);
 		}
 	}


### PR DESCRIPTION
So, turning off the parse plain URLs option with phpBB 3.2.6 leads to a fatal error, because of the update to text formatter in 3.2.6. This should address that error, while still being backwards compatible with previous version of phpBB and textformatter..