### PR TITLE
Sort media sites in the ACP

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -155,6 +155,10 @@ class main_module
 			];
 		}
 
+		usort($sites, function ($site1, $site2) {
+			return strcasecmp($site1['id'], $site2['id']);
+		});
+
 		return $sites;
 	}
 


### PR DESCRIPTION
Can't figure out how to sort the default media sites object itself without turning into an array, so this seems to be the easiest sorting solution, for the ACP.