### PR TITLE
Permissions for missing roles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	"extra": {
 		"display-name": "phpBB Media Embed PlugIn",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.2.1"
+			"phpbb/phpbb": ">=3.3.2"
 		},
 		"version-check": {
 			"host": "www.phpbb.com",

--- a/ext.php
+++ b/ext.php
@@ -12,8 +12,8 @@ namespace phpbb\mediaembed;
 
 class ext extends \phpbb\extension\base
 {
-	/** @var string Minimum requirements: phpBB 3.2.1 */
-	const PHPBB_MINIMUM = '3.2.1';
+	/** @var string Minimum requirements: phpBB 3.3.2 because using role_exists in migrations */
+	const PHPBB_MINIMUM = '3.3.2';
 
 	/** @var string YAML file extension */
 	const YML = '.yml';

--- a/migrations/m4_permissions.php
+++ b/migrations/m4_permissions.php
@@ -48,15 +48,33 @@ class m4_permissions extends \phpbb\db\migration\migration
 		return [
 			// Add forum permission
 			['permission.add', ['f_mediaembed', false]],
-			['permission.permission_set', ['ROLE_FORUM_FULL', 'f_mediaembed']],
-			['permission.permission_set', ['ROLE_FORUM_POLLS', 'f_mediaembed']],
-			['permission.permission_set', ['ROLE_FORUM_ONQUEUE', 'f_mediaembed']],
-			['permission.permission_set', ['ROLE_FORUM_STANDARD', 'f_mediaembed']],
+			['if', [
+				['permission.role_exists', ['ROLE_FORUM_FULL']],
+				['permission.permission_set', ['ROLE_FORUM_FULL', 'f_mediaembed']],
+			]],
+			['if', [
+				['permission.role_exists', ['ROLE_FORUM_POLLS']],
+				['permission.permission_set', ['ROLE_FORUM_POLLS', 'f_mediaembed']],
+			]],
+			['if', [
+				['permission.role_exists', ['ROLE_FORUM_ONQUEUE']],
+				['permission.permission_set', ['ROLE_FORUM_ONQUEUE', 'f_mediaembed']],
+			]],
+			['if', [
+				['permission.role_exists', ['ROLE_FORUM_STANDARD']],
+				['permission.permission_set', ['ROLE_FORUM_STANDARD', 'f_mediaembed']],
+			]],
 
 			// Add PM permission
 			['permission.add', ['u_pm_mediaembed']],
-			['permission.permission_set', ['ROLE_USER_FULL', 'u_pm_mediaembed']],
-			['permission.permission_set', ['ROLE_USER_STANDARD', 'u_pm_mediaembed']],
+			['if', [
+				['permission.role_exists', ['ROLE_USER_FULL']],
+				['permission.permission_set', ['ROLE_USER_FULL', 'u_pm_mediaembed']],
+			]],
+			['if', [
+				['permission.role_exists', ['ROLE_USER_STANDARD']],
+				['permission.permission_set', ['ROLE_USER_STANDARD', 'u_pm_mediaembed']],
+			]],
 			['permission.permission_set', ['REGISTERED', 'u_pm_mediaembed', 'group']],
 			['permission.permission_set', ['REGISTERED_COPPA', 'u_pm_mediaembed', 'group']],
 		];

--- a/migrations/m7_add_missing_permissions.php
+++ b/migrations/m7_add_missing_permissions.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ *
+ * phpBB Media Embed PlugIn extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2022 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\mediaembed\migrations;
+
+/**
+ * Migration 7: Add missing permissions.
+ *
+ * If the media embed forum permission has already been set, either by a previous migration
+ * or the user, then this migration will not run. Otherwise, it probably means the core forum
+ * roles don't exist anymore. So this migration will look for any custom forum roles that
+ * exist with permission to use BBCodes and assume those are safe to assign Media Embed
+ * permissions to, since it is essentially a BBCode itself.
+ */
+class m7_add_missing_permissions extends \phpbb\db\migration\migration
+{
+	/**
+	 * If f_mediaembed has already been assigned to any permission role
+	 * then this migration should not run.
+	 *
+	 * {@inheritdoc}
+	 */
+	public function effectively_installed()
+	{
+		$sql_array = [
+			'SELECT'	=> '*',
+			'FROM'		=> [
+				$this->table_prefix . 'acl_roles_data'	=> 'd',
+			],
+			'LEFT_JOIN'	=> [
+				[
+					'FROM'	=> [$this->table_prefix . 'acl_options' => 'o'],
+					'ON'	=> 'o.auth_option_id = d.auth_option_id',
+				],
+			],
+			'WHERE'		=> "o.auth_option = 'f_mediaembed'",
+		];
+
+		$sql = $this->db->sql_build_query('SELECT', $sql_array);
+		$result = $this->db->sql_query_limit($sql, 1);
+		$row = $this->db->sql_fetchrow($result);
+		$this->db->sql_freeresult($result);
+
+		return $row !== false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function depends_on()
+	{
+		return [
+			'\phpbb\mediaembed\migrations\m1_install_data',
+			'\phpbb\mediaembed\migrations\m4_permissions',
+			'\phpbb\mediaembed\migrations\m6_full_width',
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function update_data()
+	{
+		$install = [];
+
+		foreach ($this->custom_forum_roles() as $role)
+		{
+			$install[] = ['permission.permission_set', [$role, 'f_mediaembed']];
+		}
+
+		return $install;
+	}
+
+	/**
+	 * Find custom forum roles with bbcodes allowed.
+	 *
+	 * @return array An array of forum role names
+	 */
+	public function custom_forum_roles()
+	{
+		$sql_array = [
+			'SELECT'	=> 'roles.role_id, roles.role_name',
+			'FROM'		=> [
+				$this->table_prefix . 'acl_roles'	=> 'roles',
+			],
+			'LEFT_JOIN'	=> [
+				[
+					'FROM'	=> [$this->table_prefix . 'acl_roles_data' => 'data'],
+					'ON'	=> 'roles.role_id = data.role_id',
+				],
+				[
+					'FROM'	=> [$this->table_prefix . 'acl_options' => 'opts'],
+					'ON'	=> 'data.auth_option_id = opts.auth_option_id',
+				],
+			],
+			'WHERE'	=> 'opts.auth_option = "f_bbcode"
+				AND data.auth_setting = "1"
+				AND roles.role_type = "f_"
+				AND ' . $this->db->sql_in_set('roles.role_name', $this->predefined_roles(), true),
+		];
+
+		$sql = $this->db->sql_build_query('SELECT', $sql_array);
+		$result = $this->db->sql_query($sql);
+
+		$roles = [];
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$roles[$row['role_id']] = $row['role_name'];
+		}
+		$this->db->sql_freeresult($result);
+
+		return $roles;
+	}
+
+	/**
+	 * An array of phpBB's predefined forum role names
+	 *
+	 * @return array
+	 */
+	protected function predefined_roles()
+	{
+		return [
+			'ROLE_FORUM_FULL',
+			'ROLE_FORUM_STANDARD',
+			'ROLE_FORUM_NOACCESS',
+			'ROLE_FORUM_READONLY',
+			'ROLE_FORUM_LIMITED',
+			'ROLE_FORUM_BOT',
+			'ROLE_FORUM_ONQUEUE',
+			'ROLE_FORUM_POLLS',
+			'ROLE_FORUM_LIMITED_POLLS',
+		];
+	}
+}


### PR DESCRIPTION
This PR aims to deal with users who've deleted phpBB's default forum roles, causing a fatal install error https://www.phpbb.com/customise/db/extension/mediaembed/support/topic/234496

This will check if the roles exist before trying to add permissions. The only downside to this is we have to raise the min. phpBB requirement to 3.3.2 for when this check was implemented.

There's also a new migration that will try to find any custom forum roles that are allowed to use bbcodes, and it will assign media embed permission to those, but it will only do this if it failed to assign permissions previously on phpBB's default roles. This is because I don't want to just add M.E. permissions to any custom roles since this may be somebody doing an update and they already have the permissions set the way they like. So the idea here is it will add permissions to custom roles only if no M.E. forum role permissions have been set on any role yet.